### PR TITLE
Add support for kt-paperclip 7.0

### DIFF
--- a/delayed_paperclip.gemspec
+++ b/delayed_paperclip.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.0.0"
 
-  s.add_dependency 'kt-paperclip', "~> 6.4", ">= 6.4.1"
+  s.add_dependency 'kt-paperclip', ">= 6.4.1"
   s.add_dependency 'activejob', ">= 4.2"
 
   s.add_development_dependency 'mocha'


### PR DESCRIPTION
Make this gem depend on kt-paperclip >= 6.4

kt-paperclip released a new version which fixes bugs in rails 6.1.