### PR TITLE
Support `priority` in ActiveJob queue handler.

### DIFF
--- a/lib/delayed_paperclip/process_job.rb
+++ b/lib/delayed_paperclip/process_job.rb
@@ -4,7 +4,8 @@ module DelayedPaperclip
   class ProcessJob < ActiveJob::Base
     def self.enqueue_delayed_paperclip(instance_klass, instance_id, attachment_name)
       queue_name = instance_klass.constantize.paperclip_definitions[attachment_name][:delayed][:queue]
-      set(:queue => queue_name).perform_later(instance_klass, instance_id, attachment_name.to_s)
+      priority   = instance_klass.constantize.paperclip_definitions[attachment_name][:delayed][:priority]
+      set(:priority => priority, :queue => queue_name).perform_later(instance_klass, instance_id, attachment_name.to_s)
     end
 
     def perform(instance_klass, instance_id, attachment_name)


### PR DESCRIPTION
Allows you to pass in a priority when delaying a job, such as: 

```ruby
Delayed::Job.enqueue( archive_job, priority: 10 )
```